### PR TITLE
Support .aent assembler directive

### DIFF
--- a/gas/config/obj-ecoff.c
+++ b/gas/config/obj-ecoff.c
@@ -70,6 +70,7 @@ const pseudo_typeS obj_pseudo_table[] =
   { "val",	ecoff_directive_val,	0 },
 
   /* ECOFF specific debugging information.  */
+  { "aent",	ecoff_directive_ent,	1 },
   { "begin",	ecoff_directive_begin,	0 },
   { "bend",	ecoff_directive_bend,	0 },
   { "end",	ecoff_directive_end,	0 },

--- a/gas/config/obj-elf.c
+++ b/gas/config/obj-elf.c
@@ -134,6 +134,7 @@ static const pseudo_typeS ecoff_debug_pseudo_table[] =
   { "etype",	ecoff_directive_type,	0 },
 
   /* ECOFF specific debugging information.  */
+  { "aent",	ecoff_directive_ent,	1 },
   { "begin",	ecoff_directive_begin,	0 },
   { "bend",	ecoff_directive_bend,	0 },
   { "end",	ecoff_directive_end,	0 },

--- a/gas/ecoff.c
+++ b/gas/ecoff.c
@@ -3106,7 +3106,7 @@ ecoff_directive_ent (aent)
   ch = *name;
   if (! is_name_beginner (ch))
     {
-      as_warn (_(".ent directive has no name"));
+      as_warn (_("%s directive has no name"), aent ? ".aent" : ".ent");
       *input_line_pointer = name_end;
       demand_empty_rest_of_line ();
       return;

--- a/gas/ecoff.c
+++ b/gas/ecoff.c
@@ -3083,8 +3083,8 @@ ecoff_directive_end (ignore)
 /* Parse .ent directives.  */
 
 void
-ecoff_directive_ent (ignore)
-     int ignore;
+ecoff_directive_ent (aent)
+     int aent;
 {
   char *name;
   char name_end;
@@ -3093,7 +3093,7 @@ ecoff_directive_ent (ignore)
   if (cur_file_ptr == (efdr_t *) NULL)
     add_file ((const char *) NULL, 0, 1);
 
-  if (cur_proc_ptr != (proc_t *) NULL)
+  if (!aent && cur_proc_ptr != (proc_t *) NULL)
     {
       as_warn (_("second .ent directive found before .end directive"));
       demand_empty_rest_of_line ();
@@ -3112,7 +3112,8 @@ ecoff_directive_ent (ignore)
       return;
     }
 
-  add_procedure (name);
+  if (!aent)
+    add_procedure (name);
 
   *input_line_pointer = name_end;
 


### PR DESCRIPTION
Tested on ultralib iQue branch, no longer fails to build and also produces matching symbol table
